### PR TITLE
Skip dump indices which lie entirely before the requested search range.

### DIFF
--- a/client/src/me/mdbell/noexs/ui/services/MemorySearchService.java
+++ b/client/src/me/mdbell/noexs/ui/services/MemorySearchService.java
@@ -260,8 +260,10 @@ public class MemorySearchService extends Service<SearchResult> {
             long size = res.curr.getSize();
             long start = supplier.getStart();
             for (DumpIndex idx : indices) {
-                if (isCancelled() || idx.getAddress() >= supplier.getEnd()) {
-                    break;
+                if (isCancelled() ||
+                    idx.getAddress() >= supplier.getEnd() ||
+                    idx.getEndAddress() <= start) {
+                    continue;
                 }
                 updateMessage("Searching...");
                 ByteBuffer b = res.curr.getBuffer(idx);


### PR DESCRIPTION
Added to the existing check for ones that lie entirely after.  Without this, position() can throw an exception.