### PR TITLE
Get the stage width and height dynamically

### DIFF
--- a/client/src/me/mdbell/noexs/ui/NoexsApplication.java
+++ b/client/src/me/mdbell/noexs/ui/NoexsApplication.java
@@ -29,6 +29,7 @@ public class NoexsApplication extends Application {
         FXMLLoader loader = new FXMLLoader(getClass().getResource(("views/Main.fxml")));
         Parent root = loader.load();
         stage.setResizable(false);
+        stage.show();
         stage.setScene(new Scene(root, stage.getWidth(), stage.getHeight()));
         MainController c = loader.getController();
         c.setStage(stage);
@@ -37,6 +38,5 @@ public class NoexsApplication extends Application {
             c.stop();
             Platform.exit();
         });
-        stage.show();
     }
 }


### PR DESCRIPTION
I noticed on i3wm that I have this giant white slate with a tiny tiny set of utilities in the top left corner. Digging into it, looks like the stage `getWidth()` and `getHeight()` will return `0` if the stage is not shown first. This should actually set the height to whatever the window manager provides for it.

Stack Overflow link: https://stackoverflow.com/questions/55172310/how-to-position-the-window-stage-in-javafx